### PR TITLE
:sparkles: Adds support for Redis TLS

### DIFF
--- a/caches/core.py
+++ b/caches/core.py
@@ -12,6 +12,7 @@ class Cache:
         "dummy": "caches.backends.dummy:DummyBackend",
         "locmem": "caches.backends.locmem:LocMemBackend",
         "redis": "caches.backends.redis:RedisBackend",
+        "rediss": "caches.backends.redis:RedisBackend",
     }
 
     def __init__(
@@ -42,7 +43,7 @@ class Cache:
         self.options = options
         self.is_connected = False
 
-        assert self.url.backend in self.SUPPORTED_BACKENDS, "Invalid backend."
+        assert self.url.backend in self.SUPPORTED_BACKENDS, f"Invalid backend {self.url.backend}."
         backend_str = self.SUPPORTED_BACKENDS[self.url.backend]
         backend_cls = import_from_string(backend_str)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2'
+
+services:
+  redis:
+    image: redis:6
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
We're using this package with rediss protocol and it seems to work
without further changes.
Also made the assert error more explicit to help pinpointing errors
earlier.
Provide the `docker-compose.yml` file for easy local testing, use with:
```sh
docker-compose up redis
```